### PR TITLE
Add support for additional about pages

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -57,6 +57,9 @@ export default [{
   path: '/about',
   component: AboutPage,
 }, {
+  path: '/about/:page',
+  component: AboutPage,
+}, {
   path: '/communities',
   component: OrganizationsPage,
 }, {


### PR DESCRIPTION
There was only an /about route in routes.js, with no support for
additional about pages like /about/general-info.

Adding a route /about/:page gives support for /about/general-info and
other pages in the future.

Fixes: #41