### PR TITLE
Allows for @ in urls for profile edits

### DIFF
--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -17,7 +17,7 @@ Validator.registerAsync('accountname', (accountName, attribute, req, passes) => 
 });
 
 Validator.register(
-  'shortUrl', value => value.match(/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/),
+  'shortUrl', value => value.match(/^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w @\.-]*)*\/?$/),
   'The :attribute format is invalid.',
 );
 


### PR DESCRIPTION
Use Case: When users want to edit their profile and add a link with an @ sign in it, it will say 'The field name url format is invalid'. If someone wanted their website url to be a Whaleshares or Steem link, it won't let them. This PR adds support for @ signs in urls.
![image](https://user-images.githubusercontent.com/14302151/54948988-5aa1bc80-4f14-11e9-9141-6bcdbcc58264.png)
